### PR TITLE
feat: allow k8s-clusters commit messages tool message formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Slack Notify kubernetes GitHub Action
 
-This action is used to notify deployments in kubernetes via Slack
+This action is used to notify deployments in kubernetes via Slack.
+
+It takes into account different commit message formats to create a more meaningful Slack message.
 
 ## Inputs
 

--- a/commit-parser.js
+++ b/commit-parser.js
@@ -1,0 +1,203 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CommitType = void 0;
+exports.getCommitMessageTitle = getCommitMessageTitle;
+exports.isDeploymentCommit = isDeploymentCommit;
+var CommitType;
+(function (CommitType) {
+    CommitType["VERSION"] = "version";
+    CommitType["CONFIG"] = "config";
+    CommitType["MULTIPLE"] = "multiple";
+})(CommitType || (exports.CommitType = CommitType = {}));
+function getCommitMessageTitle(commit) {
+    return commit.commitMessage.split("\n")[0];
+}
+// Single service with version pattern
+function matchSingleServiceWithVersion(commitTitle) {
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Single service config changes pattern
+function matchSingleServiceConfig(commitTitle) {
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+config\s+changes\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.CONFIG,
+            service: match[2],
+            version: "config",
+            environment: match[3].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Multiple services in same domain pattern
+function matchMultipleServices(commitTitle) {
+    const pattern = /^Deploy\s+(\S+)\s+services\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.MULTIPLE,
+            service: "services",
+            version: "multiple",
+            environment: match[2].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Multiple services config changes pattern
+function matchMultipleServicesConfig(commitTitle) {
+    const pattern = /^Deploy\s+(\S+)\s+services\s+config\s+changes\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.CONFIG,
+            service: "services",
+            version: "config",
+            environment: match[2].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Multiple environments pattern
+function matchMultipleEnvironments(commitTitle) {
+    const pattern = /^Deploy\s+(\S+)\s+services\s+to\s+((?:sta|prod|dev)(?:\s+and\s+(?:sta|prod|dev))+)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        const envs = match[2].toLowerCase();
+        const firstEnv = envs.split(/\s+and\s+/)[0];
+        return {
+            domain: match[1],
+            type: CommitType.MULTIPLE,
+            service: "services",
+            version: "multiple-envs",
+            environment: firstEnv,
+        };
+    }
+    return null;
+}
+// Multiple domains pattern
+function matchMultipleDomains(commitTitle) {
+    const pattern = /^Deploy\s+multiple\s+services\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: "multiple",
+            type: CommitType.MULTIPLE,
+            service: "services",
+            version: "multiple",
+            environment: match[1].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Multiple domains config changes pattern
+function matchMultipleDomainsConfig(commitTitle) {
+    const pattern = /^Deploy\s+config\s+changes\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: "multiple",
+            type: CommitType.CONFIG,
+            service: "config",
+            version: "config",
+            environment: match[1].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Grouped chart deployments pattern
+function matchGroupedChart(commitTitle) {
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Legacy v1 format pattern
+function matchLegacyV1Format(commitTitle) {
+    const pattern = /^Deployed\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Legacy v2 format pattern
+function matchLegacyV2Format(commitTitle) {
+    const pattern = /Deploy\s(\w\S+)\s(\w\S+)\sversion\s(v\d+\.\d+\.\d+\S*)\sto\s(prod|sta|dev)/i;
+    const match = commitTitle.match(pattern);
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+// Main orchestrator function
+function isDeploymentCommit(commit) {
+    const commitTitle = getCommitMessageTitle(commit);
+    // Array of matcher functions in priority order
+    const matchers = [
+        matchSingleServiceWithVersion,
+        matchSingleServiceConfig,
+        matchMultipleServices,
+        matchMultipleServicesConfig,
+        matchMultipleEnvironments,
+        matchMultipleDomains,
+        matchMultipleDomainsConfig,
+        matchGroupedChart,
+        matchLegacyV1Format,
+        matchLegacyV2Format,
+    ];
+    // Try each matcher until one succeeds
+    for (const matcher of matchers) {
+        const result = matcher(commitTitle);
+        if (result) {
+            console.log(`Matched pattern: ${matcher.name}`);
+            console.log("commitMessageDetails:", result);
+            return { ok: true, commitMessage: result };
+        }
+    }
+    // No match found
+    return {
+        ok: false,
+        commitMessage: {
+            domain: "",
+            type: CommitType.CONFIG,
+            service: "",
+            version: "",
+            environment: "",
+        },
+    };
+}

--- a/commit-parser.js
+++ b/commit-parser.js
@@ -119,21 +119,6 @@ function matchMultipleDomainsConfig(commitTitle) {
     }
     return null;
 }
-// Grouped chart deployments pattern
-function matchGroupedChart(commitTitle) {
-    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
-    const match = commitTitle.match(pattern);
-    if (match) {
-        return {
-            domain: match[1],
-            type: CommitType.VERSION,
-            service: match[2],
-            version: match[3],
-            environment: match[4].toLowerCase(),
-        };
-    }
-    return null;
-}
 // Legacy v1 format pattern
 function matchLegacyV1Format(commitTitle) {
     const pattern = /^Deployed\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
@@ -151,7 +136,7 @@ function matchLegacyV1Format(commitTitle) {
 }
 // Legacy v2 format pattern
 function matchLegacyV2Format(commitTitle) {
-    const pattern = /Deploy\s(\w\S+)\s(\w\S+)\sversion\s(v\d+\.\d+\.\d+\S*)\sto\s(prod|sta|dev)/i;
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
     const match = commitTitle.match(pattern);
     if (match) {
         return {
@@ -176,7 +161,6 @@ function isDeploymentCommit(commit) {
         matchMultipleEnvironments,
         matchMultipleDomains,
         matchMultipleDomainsConfig,
-        matchGroupedChart,
         matchLegacyV1Format,
         matchLegacyV2Format,
     ];

--- a/commit-parser.ts
+++ b/commit-parser.ts
@@ -1,0 +1,240 @@
+export interface Commit {
+    url: string;
+    authorUsername: string;
+    authorEmail: string;
+    commitMessage: string;
+}
+
+export interface CommitMessageDetails {
+    domain: string;
+    type: CommitType;
+    service: string;
+    version: string;
+    environment: string;
+}
+
+export enum CommitType {
+    VERSION = "version",
+    CONFIG = "config",
+    MULTIPLE = "multiple",
+}
+
+export function getCommitMessageTitle(commit: Commit): string {
+    return commit.commitMessage.split("\n")[0];
+}
+
+// Single service with version pattern
+function matchSingleServiceWithVersion(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Single service config changes pattern
+function matchSingleServiceConfig(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+config\s+changes\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.CONFIG,
+            service: match[2],
+            version: "config",
+            environment: match[3].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Multiple services in same domain pattern
+function matchMultipleServices(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+(\S+)\s+services\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.MULTIPLE,
+            service: "services",
+            version: "multiple",
+            environment: match[2].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Multiple services config changes pattern
+function matchMultipleServicesConfig(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+(\S+)\s+services\s+config\s+changes\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.CONFIG,
+            service: "services",
+            version: "config",
+            environment: match[2].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Multiple environments pattern
+function matchMultipleEnvironments(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+(\S+)\s+services\s+to\s+((?:sta|prod|dev)(?:\s+and\s+(?:sta|prod|dev))+)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        const envs = match[2].toLowerCase();
+        const firstEnv = envs.split(/\s+and\s+/)[0];
+        return {
+            domain: match[1],
+            type: CommitType.MULTIPLE,
+            service: "services",
+            version: "multiple-envs",
+            environment: firstEnv,
+        };
+    }
+    return null;
+}
+
+// Multiple domains pattern
+function matchMultipleDomains(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+multiple\s+services\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: "multiple",
+            type: CommitType.MULTIPLE,
+            service: "services",
+            version: "multiple",
+            environment: match[1].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Multiple domains config changes pattern
+function matchMultipleDomainsConfig(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+config\s+changes\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: "multiple",
+            type: CommitType.CONFIG,
+            service: "config",
+            version: "config",
+            environment: match[1].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Grouped chart deployments pattern
+function matchGroupedChart(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Legacy v1 format pattern
+function matchLegacyV1Format(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /^Deployed\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Legacy v2 format pattern
+function matchLegacyV2Format(commitTitle: string): CommitMessageDetails | null {
+    const pattern = /Deploy\s(\w\S+)\s(\w\S+)\sversion\s(v\d+\.\d+\.\d+\S*)\sto\s(prod|sta|dev)/i;
+    const match = commitTitle.match(pattern);
+
+    if (match) {
+        return {
+            domain: match[1],
+            type: CommitType.VERSION,
+            service: match[2],
+            version: match[3],
+            environment: match[4].toLowerCase(),
+        };
+    }
+    return null;
+}
+
+// Main orchestrator function
+export function isDeploymentCommit(commit: Commit): {
+    ok: boolean;
+    commitMessage: CommitMessageDetails;
+} {
+    const commitTitle = getCommitMessageTitle(commit);
+
+    // Array of matcher functions in priority order
+    const matchers = [
+        matchSingleServiceWithVersion,
+        matchSingleServiceConfig,
+        matchMultipleServices,
+        matchMultipleServicesConfig,
+        matchMultipleEnvironments,
+        matchMultipleDomains,
+        matchMultipleDomainsConfig,
+        matchGroupedChart,
+        matchLegacyV1Format,
+        matchLegacyV2Format,
+    ];
+
+    // Try each matcher until one succeeds
+    for (const matcher of matchers) {
+        const result = matcher(commitTitle);
+        if (result) {
+            console.log(`Matched pattern: ${matcher.name}`);
+            console.log("commitMessageDetails:", result);
+            return { ok: true, commitMessage: result };
+        }
+    }
+
+    // No match found
+    return {
+        ok: false,
+        commitMessage: {
+            domain: "",
+            type: CommitType.CONFIG,
+            service: "",
+            version: "",
+            environment: "",
+        },
+    };
+}

--- a/commit-parser.ts
+++ b/commit-parser.ts
@@ -144,23 +144,6 @@ function matchMultipleDomainsConfig(commitTitle: string): CommitMessageDetails |
     return null;
 }
 
-// Grouped chart deployments pattern
-function matchGroupedChart(commitTitle: string): CommitMessageDetails | null {
-    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
-    const match = commitTitle.match(pattern);
-
-    if (match) {
-        return {
-            domain: match[1],
-            type: CommitType.VERSION,
-            service: match[2],
-            version: match[3],
-            environment: match[4].toLowerCase(),
-        };
-    }
-    return null;
-}
-
 // Legacy v1 format pattern
 function matchLegacyV1Format(commitTitle: string): CommitMessageDetails | null {
     const pattern = /^Deployed\s+(\S+)\s+(\S+)\s+version\s+(v?\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
@@ -180,7 +163,7 @@ function matchLegacyV1Format(commitTitle: string): CommitMessageDetails | null {
 
 // Legacy v2 format pattern
 function matchLegacyV2Format(commitTitle: string): CommitMessageDetails | null {
-    const pattern = /Deploy\s(\w\S+)\s(\w\S+)\sversion\s(v\d+\.\d+\.\d+\S*)\sto\s(prod|sta|dev)/i;
+    const pattern = /^Deploy\s+(\S+)\s+(\S+)\s+version\s+(v\d+\.\d+\.\d+\S*)\s+to\s+(prod|sta|dev)$/i;
     const match = commitTitle.match(pattern);
 
     if (match) {
@@ -211,7 +194,6 @@ export function isDeploymentCommit(commit: Commit): {
         matchMultipleEnvironments,
         matchMultipleDomains,
         matchMultipleDomainsConfig,
-        matchGroupedChart,
         matchLegacyV1Format,
         matchLegacyV2Format,
     ];

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import { WebClient } from "@slack/web-api";
+import { isDeploymentCommit, CommitType, type Commit, type CommitMessageDetails } from "./commit-parser";
 
 // Load environment variables when running locally
 if (process.env.NODE_ENV !== "test") {
@@ -31,24 +32,6 @@ function getInputWithFallback(name: string): string {
   return envVar ? process.env[envVar] || "" : "";
 }
 
-export interface Commit {
-  url: string;
-  authorUsername: string;
-  authorEmail: string;
-  commitMessage: string;
-}
-
-export interface CommitMessageDetails {
-  domain: string;
-  service: string;
-  version: string;
-  environment: string;
-}
-
-function getCommitMessageTitle(commit: Commit): string {
-  return commit.commitMessage.split("\n")[0];
-}
-
 async function main(): Promise<void> {
   try {
     console.log("Running actions-notify-slack-k8s");
@@ -65,10 +48,7 @@ async function main(): Promise<void> {
     // Example: "#deploys-mas-billing-prod"
     const slackChannel = `#deploys-${commitMessage.domain}-${commitMessage.environment}`;
 
-    let message = `:rocket: Deployed ${commitMessage.domain} \`${commitMessage.service}\` version \`${commitMessage.version}\` to <${commit.url}|${commitMessage.environment}>`;
-    if (commit.authorUsername !== "") {
-      message += ` by _${commit.authorUsername}_`;
-    }
+    const message = buildSlackMessage(commit, commitMessage);
 
     const ts = await sendMessageToChannel(slackClient, slackChannel, message);
     console.log("ts:", ts);
@@ -102,62 +82,39 @@ export function buildCommit(): Commit {
   };
 }
 
-export function isDeploymentCommit(commit: Commit): {
-  ok: boolean;
-  commitMessage: CommitMessageDetails;
-} {
-  // Try v1 format first
-  // Examples: "Deployed mas-billing api-billing version v1.37.0 to prod"
-  //           "Deployed mas-billing api-billing version v1.37.0-RC.2 to sta"
-  //           "Deployed mas-billing api-billing version v1.37.0 to STA"
-  const v1Pattern =
-    /Deployed\s(\w\S+)\s(\w\S+)\sversion\s(v\d+\.\d+\.\d+\S*)\sto\s(prod|sta|dev)/i;
-  const v1Matches = getCommitMessageTitle(commit).match(v1Pattern);
+function buildSlackMessage(commit: Commit, commitMessage: CommitMessageDetails): string {
+  const baseUrl = `<${commit.url}|${commitMessage.environment}>`;
+  const author = commit.authorUsername !== "" ? ` by _${commit.authorUsername}_` : "";
 
-  if (v1Matches && v1Matches.length > 0) {
-    const commitMessage: CommitMessageDetails = {
-      domain: v1Matches[1],
-      service: v1Matches[2],
-      version: v1Matches[3],
-      environment: v1Matches[4],
-    };
+  switch (commitMessage.type) {
+    case CommitType.VERSION:
+      if (commitMessage.domain === "multiple") {
+        return `:rocket: Deployed multiple services version \`${commitMessage.version}\` to ${baseUrl}${author}`;
+      }
+      return `:rocket: Deployed ${commitMessage.domain} \`${commitMessage.service}\` version \`${commitMessage.version}\` to ${baseUrl}${author}`;
 
-    console.log("matched v1 string:", v1Matches[0]);
-    console.log("commitMessageDetails:", commitMessage);
+    case CommitType.CONFIG:
+      if (commitMessage.domain === "multiple" && commitMessage.service === "config") {
+        return `:gear: Deployed config changes to ${baseUrl}${author}`;
+      }
+      if (commitMessage.service === "services") {
+        return `:gear: Deployed ${commitMessage.domain} services config changes to ${baseUrl}${author}`;
+      }
+      return `:gear: Deployed ${commitMessage.domain} \`${commitMessage.service}\` config changes to ${baseUrl}${author}`;
 
-    return { ok: true, commitMessage };
+    case CommitType.MULTIPLE:
+      if (commitMessage.domain === "multiple") {
+        return `:rocket: Deployed multiple services to ${baseUrl}${author}`;
+      }
+      if (commitMessage.version === "multiple-envs") {
+        return `:rocket: Deployed ${commitMessage.domain} services to multiple environments${author}`;
+      }
+      return `:rocket: Deployed ${commitMessage.domain} services to ${baseUrl}${author}`;
+
+    default:
+      // Fallback to original format
+      return `:rocket: Deployed ${commitMessage.domain} \`${commitMessage.service}\` version \`${commitMessage.version}\` to ${baseUrl}${author}`;
   }
-
-  // Try v2 format
-  // Example: "Deploy mas-billing rating-engine version v1.132.5 to prod"
-  const v2Pattern =
-    /Deploy\s(\w\S+)\s(\w\S+)\sversion\s(v\d+\.\d+\.\d+\S*)\sto\s(prod|sta|dev)/i;
-  const v2Matches = getCommitMessageTitle(commit).match(v2Pattern);
-
-  if (v2Matches && v2Matches.length > 0) {
-    const commitMessage: CommitMessageDetails = {
-      domain: v2Matches[1],
-      service: v2Matches[2],
-      version: v2Matches[3],
-      environment: v2Matches[4],
-    };
-
-    console.log("matched v2 string:", v2Matches[0]);
-    console.log("commitMessageDetails:", commitMessage);
-
-    return { ok: true, commitMessage };
-  }
-
-  // No match found
-  return {
-    ok: false,
-    commitMessage: {
-      domain: "",
-      service: "",
-      version: "",
-      environment: "",
-    },
-  };
 }
 
 async function sendMessageToChannel(


### PR DESCRIPTION
This pull request refactors the commit parsing logic to support a wider variety of commit message formats for Kubernetes deployments, enhancing both the accuracy and flexibility of Slack notifications. The main changes include extracting commit parsing into a dedicated module, expanding pattern matching for different deployment scenarios, updating tests to cover new cases, and improving documentation to reflect these capabilities.

**Commit parsing and message handling improvements:**

* Added a new module `commit-parser.ts` (and its compiled output `commit-parser.js`) that centralizes all commit parsing logic, including type definitions and multiple pattern matchers for different commit message formats. This enables more robust detection of deployments and config changes across single/multiple services, environments, and domains. [[1]](diffhunk://#diff-bd292c1f6a894c6114e2d54c34a570efa7889a4e9de41f2137143dae9eaf3b15R1-R240) [[2]](diffhunk://#diff-1a36c23f3d55dcbdffa1904c6bd0552a8ca4c04545f0d8b60208d6c213d7763bR1-R203)
* Refactored `main.ts` to use the new commit parsing module, removing duplicate type definitions and logic, and delegating Slack message construction to a dedicated function for improved maintainability. [[1]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R3) [[2]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L34-L51) [[3]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L68-R51)

**Testing enhancements:**

* Updated and expanded unit tests in `main.test.ts` to cover all supported commit message patterns, including single service config changes, multiple services, multiple environments, multiple domains, grouped chart deployments, and legacy formats. Also normalized environment casing in test expectations. [[1]](diffhunk://#diff-ed41aaa56fae8955334aa2a56bc4f779bcecbbe1b4b66ca756a5c3c8c4f3bb58L10-R10) [[2]](diffhunk://#diff-ed41aaa56fae8955334aa2a56bc4f779bcecbbe1b4b66ca756a5c3c8c4f3bb58L119-R119) [[3]](diffhunk://#diff-ed41aaa56fae8955334aa2a56bc4f779bcecbbe1b4b66ca756a5c3c8c4f3bb58R216-R362)

**Documentation:**

* Updated `README.md` to clarify that the action now supports multiple commit message formats for more meaningful Slack notifications.